### PR TITLE
adding solution for pod,svc problem

### DIFF
--- a/Troubleshooting/pod-service/app-pod.yaml
+++ b/Troubleshooting/pod-service/app-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-pod
+  labels:
+    app: app-lab
+spec:
+  containers:
+  - name: app-container
+    image: httpd:latest
+    ports:
+    - containerPort: 80

--- a/Troubleshooting/pod-service/app-svc.yaml
+++ b/Troubleshooting/pod-service/app-svc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-svc
+spec:
+  selector:
+    app: app-lab
+  ports:
+  - port: 80
+    targetPort: 80
+  type: ClusterIP


### PR DESCRIPTION
I'm adding a solution for this problem which I didn't find in the repository
```
You need to create a Kubernetes Pod and a Service to host a simple web application that prints "It works!" when accessed. Follow these steps:

Create a Pod named app-pod with the following specifications:

Container name: app-container
Container image: httpd:latest
Container port: 80
Create a Service named app-svc with the following specifications:

Select the Pod with the label app: app-lab .

Service port: 80

Target port: 80

Service type: ClusterIP

kubectl port-forward to forward a local port to the Pod's port

Access the web application using curl on another terminal

```